### PR TITLE
Fixed: Bug #2 Country Heritage Sites

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -42,8 +42,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "8kB",
-                  "maximumError": "16kB"
+                  "maximumWarning": "16kB",
+                  "maximumError": "24kB"
                 }
               ],
               "outputHashing": "all"

--- a/src/app/components/country-detail/country-detail.component.css
+++ b/src/app/components/country-detail/country-detail.component.css
@@ -250,9 +250,113 @@
     font-weight: 500
 }
 
+/* ── Map wrapper — detail panel floats over it as an overlay ── */
+.map-detail-layout {
+    position: relative;
+    margin-bottom: 1.25rem
+}
+
+/* Map always takes the full width — the panel never pushes it */
 .country-map-section {
-    margin-bottom: 1.25rem;
-    padding: 1rem
+    padding: 1rem;
+    width: 100%
+}
+
+/* ── Floating detail panel — fixed to right side of viewport ── */
+.site-detail-panel {
+    position: fixed;
+    top: 5.5rem;
+    right: 0;
+    width: 320px;
+    height: auto;
+    max-height: calc(100vh - 6.5rem);
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    overflow: hidden;
+    background: var(--bg-card);
+    border-left: 1px solid var(--glass-border);
+    border-top: 1px solid var(--glass-border);
+    border-bottom: 1px solid var(--glass-border);
+    border-radius: 14px 0 0 14px;
+    box-shadow: -4px 4px 24px rgba(0, 0, 0, .25);
+    z-index: 200;
+    animation: slideInPanel .2s ease
+}
+
+@keyframes slideInPanel {
+    from {
+        opacity: 0;
+        transform: translateY(-8px)
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0)
+    }
+}
+
+.detail-panel-header {
+    padding: 1.25rem 1.25rem .75rem;
+    border-bottom: 1px solid var(--glass-border)
+}
+
+.detail-panel-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    margin-bottom: .6rem
+}
+
+.detail-close-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 1px solid var(--glass-border);
+    background: var(--bg-card);
+    color: var(--text-muted);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: background .15s ease, color .15s ease
+}
+
+.detail-close-btn:hover {
+    background: var(--glass-hover);
+    color: var(--text-main)
+}
+
+.detail-panel-name {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--text-main);
+    margin: 0;
+    line-height: 1.35
+}
+
+.detail-panel-body {
+    padding: 1rem 1.25rem;
+    flex: 1;
+    overflow-y: auto
+}
+
+.detail-panel-desc {
+    font-size: .875rem;
+    color: var(--text-muted);
+    line-height: 1.65;
+    margin: 0 0 1.25rem
+}
+
+.detail-panel-actions {
+    display: flex;
+    gap: .75rem
+}
+
+.mobile-bottom-sheet {
+    display: none
 }
 
 .tabs-container {
@@ -347,7 +451,8 @@
     min-width: 0
 }
 
-.item-card:hover {
+.item-card:hover,
+.item-card.hovered {
     transform: translateY(-2px);
     box-shadow: 0 6px 20px var(--shadow-color);
     background: var(--glass-hover)
@@ -356,6 +461,11 @@
 .item-card.visited {
     background: rgba(var(--primary-rgb), .1);
     border-color: rgba(var(--primary-rgb), .4)
+}
+
+.item-card.selected {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 2px rgba(var(--primary-rgb), .3)
 }
 
 .item-name {
@@ -464,7 +574,7 @@
     line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    word-break: break-all
+    word-break: break-word
 }
 
 .empty-state {
@@ -478,9 +588,113 @@
     margin: 0
 }
 
+@media(max-width:900px) {
+
+    /* Floating overlay panel switches to rendering below the map */
+    .site-detail-panel {
+        position: static;
+        width: 100%;
+        max-height: none;
+        border-radius: 14px;
+        margin-top: 1rem;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, .2)
+    }
+
+    /* On mobile (<=600px) hide the static panel and use the bottom sheet */
+}
+
+@media(max-width:600px) {
+    .site-detail-panel {
+        display: none
+    }
+
+    /* Show mobile bottom sheet */
+    .mobile-bottom-sheet {
+        display: flex;
+        flex-direction: column;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 500;
+        background: var(--bg-card);
+        border-top: 1px solid var(--glass-border);
+        border-radius: 18px 18px 0 0;
+        box-shadow: 0 -8px 32px rgba(0, 0, 0, .25);
+        /* Start peeked — shows handle + badge + title + partial description */
+        max-height: 45vh;
+        transition: max-height .3s cubic-bezier(.4, 0, .2, 1);
+        /* Let vertical swipes pass through to our handler, block horizontal */
+        touch-action: pan-y
+    }
+
+    .mobile-bottom-sheet.expanded {
+        max-height: 88vh
+    }
+
+    .sheet-handle-wrap {
+        padding: .75rem;
+        display: flex;
+        justify-content: center;
+        flex-shrink: 0;
+        /* Prevent browser from stealing the drag gesture on the handle */
+        touch-action: none;
+        user-select: none
+    }
+
+    .sheet-handle {
+        width: 44px;
+        height: 4px;
+        background: var(--glass-border);
+        border-radius: 2px
+    }
+
+    .sheet-content {
+        overflow-y: auto;
+        flex: 1;
+        /* Stop iOS rubber-banding from conflicting with the collapse gesture */
+        overscroll-behavior: contain
+    }
+
+    .sheet-header {
+        padding: 0 1.25rem .9rem;
+        border-bottom: 1px solid var(--glass-border)
+    }
+
+    .sheet-title-row {
+        display: flex;
+        align-items: flex-start;
+        gap: .5rem
+    }
+
+    .sheet-name {
+        font-size: .95rem;
+        font-weight: 700;
+        color: var(--text-main);
+        margin: 0;
+        flex: 1;
+        min-width: 0;
+        line-height: 1.35
+    }
+
+    .sheet-body {
+        padding: 1rem 1.25rem
+    }
+}
+
 @media(max-width:768px) {
     .country-detail-container {
         padding: 1.25rem .75rem .75rem
+    }
+
+    .tabs-container {
+        /* Small baseline breathing room */
+        padding-bottom: 1.5rem
+    }
+
+    /* When the bottom sheet is open, push content up so the last item is reachable */
+    .country-detail-container.sheet-open .tabs-container {
+        padding-bottom: 1.5rem
     }
 
     .items-grid {
@@ -507,94 +721,6 @@
     .btn-visited {
         width: 100%
     }
-
-    .modal-header {
-        padding: 2rem 1.25rem 1.25rem
-    }
-
-    .modal-body {
-        padding: 1.25rem
-    }
-
-    .modal-actions {
-        flex-direction: column
-    }
-}
-
-.modal-overlay {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, .75);
-    backdrop-filter: blur(8px);
-    z-index: 1000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1rem
-}
-
-.modal-content {
-    width: 100%;
-    max-width: 600px;
-    max-height: 90vh;
-    overflow-y: auto;
-    background: var(--bg-card);
-    border: 1px solid var(--glass-border);
-    position: relative;
-    display: flex;
-    flex-direction: column
-}
-
-.modal-close {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    font-size: 2rem;
-    cursor: pointer;
-    line-height: 1;
-    z-index: 10;
-    transition: color .2s ease
-}
-
-.modal-close:hover {
-    color: var(--text-main)
-}
-
-.modal-header {
-    padding: 2.5rem 2rem 1.5rem;
-    border-bottom: 1px solid var(--glass-border)
-}
-
-.modal-title {
-    font-size: 1.75rem;
-    margin-top: .75rem
-}
-
-.modal-body {
-    padding: 2rem
-}
-
-.modal-description h3 {
-    font-size: 1.1rem;
-    margin-bottom: .75rem;
-    color: var(--text-main)
-}
-
-.modal-description p {
-    color: var(--text-muted);
-    line-height: 1.7;
-    font-size: .95rem
-}
-
-.modal-actions {
-    margin-top: 2.5rem;
-    display: flex;
-    gap: 1rem;
-    border-top: 1px solid var(--glass-border);
-    padding-top: 1.5rem
 }
 
 @keyframes fadeIn {

--- a/src/app/components/country-detail/country-detail.component.html
+++ b/src/app/components/country-detail/country-detail.component.html
@@ -1,4 +1,4 @@
-<div class="country-detail-container" *ngIf="vm$ | async as vm">
+<div class="country-detail-container" [class.sheet-open]="selectedSite" *ngIf="vm$ | async as vm">
 
     <!-- Floating back button -->
     <button class="back-btn" (click)="goBack()" title="Back to Explore">
@@ -85,14 +85,50 @@
         </div>
     </div>
 
-    <!-- Country Map -->
-    <div class="country-map-section glass-panel fade-in">
-        <app-world-map [focusedCountry]="vm.country || null"
-            [visitedCountryNames]="vm.isVisited ? [vm.country?.name || ''] : []" [heritageSites]="vm.heritageSites"
-            [visitedPOIIds]="vm.profile?.visitedPOIs || []" [countryId]="vm.country?.id || ''" [height]="'360px'"
-            [visitedSubdivisionCodes]="vm.profile?.visitedSubdivisions || []"
-            (poiToggled)="openSiteFromPin($event, vm.heritageSites)">
-        </app-world-map>
+    <!-- Two-column layout: map + optional site detail panel -->
+    <div class="map-detail-layout">
+
+        <!-- Country Map -->
+        <div class="country-map-section glass-panel fade-in">
+            <app-world-map [focusedCountry]="vm.country || null"
+                [visitedCountryNames]="vm.isVisited ? [vm.country?.name || ''] : []" [heritageSites]="vm.heritageSites"
+                [visitedPOIIds]="vm.profile?.visitedPOIs || []" [countryId]="vm.country?.id || ''" [height]="'360px'"
+                [visitedSubdivisionCodes]="vm.profile?.visitedSubdivisions || []" [highlightedSiteId]="hoveredSiteId"
+                [highlightedSubdivisionCode]="hoveredSubdivisionCode"
+                (poiToggled)="openSiteFromPin($event, vm.heritageSites)">
+            </app-world-map>
+        </div>
+
+        <!-- Inline Site Detail Panel (desktop sidebar, hidden on mobile) -->
+        <div class="site-detail-panel glass-panel fade-in" *ngIf="selectedSite">
+            <div class="detail-panel-header">
+                <div class="detail-panel-title-row">
+                    <span class="heritage-badge" [class.badge-cultural]="selectedSite.category_short === 'C'"
+                        [class.badge-natural]="selectedSite.category_short === 'N'"
+                        [class.badge-mixed]="selectedSite.category_short === 'C/N' || selectedSite.category_short === 'N/C'">
+                        {{ selectedSite.category_short === 'C' ? 'Cultural' : selectedSite.category_short === 'N' ?
+                        'Natural' : 'Mixed' }}
+                    </span>
+                    <button class="detail-close-btn" (click)="closeSiteDetails()" title="Close">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2.5" stroke-linecap="round">
+                            <line x1="18" y1="6" x2="6" y2="18" />
+                            <line x1="6" y1="6" x2="18" y2="18" />
+                        </svg>
+                    </button>
+                </div>
+                <h2 class="detail-panel-name">{{ selectedSite.name_en }}</h2>
+            </div>
+            <div class="detail-panel-body">
+                <p class="detail-panel-desc">{{ selectedSite.short_description_en }}</p>
+                <div class="detail-panel-actions" *ngIf="vm$ | async as vm2">
+                    <button class="btn-visited" [class.visited]="isPOIVisited(selectedSite.id_no, vm2.profile)"
+                        (click)="togglePOIVisited(selectedSite.id_no, vm2.profile, vm2.country?.id)">
+                        {{ isPOIVisited(selectedSite.id_no, vm2.profile) ? 'Visited ✓' : 'Mark Visited' }}
+                    </button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- Tabs -->
@@ -119,6 +155,9 @@
                         <div class="items-grid">
                             <div *ngFor="let subdivision of group.subdivisions" class="item-card glass-panel"
                                 [class.visited]="isSubdivisionVisited(subdivision.code, vm.profile)"
+                                [class.hovered]="hoveredSubdivisionCode === subdivision.code"
+                                (mouseenter)="setSubdivisionHover(subdivision.code)"
+                                (mouseleave)="setSubdivisionHover(null)"
                                 (click)="toggleSubdivisionVisited(subdivision.code, vm.profile, vm.country?.id)">
                                 <div class="item-name">{{ subdivision.name }}</div>
                                 <div class="visit-indicator"></div>
@@ -135,7 +174,10 @@
             <div *ngIf="activeTab === 'heritage'" class="tab-panel fade-in">
                 <div *ngIf="vm.heritageSites.length > 0" class="items-grid">
                     <div *ngFor="let site of vm.heritageSites" class="item-card glass-panel heritage-card"
-                        [class.visited]="isPOIVisited(site.id_no, vm.profile)" (click)="openSiteDetails(site)">
+                        [class.visited]="isPOIVisited(site.id_no, vm.profile)"
+                        [class.selected]="selectedSite?.id_no === site.id_no"
+                        [class.hovered]="hoveredSiteId === site.id_no" (mouseenter)="setSiteHover(site.id_no)"
+                        (mouseleave)="setSiteHover(null)" (click)="openSiteDetails(site)">
                         <div class="heritage-header">
                             <div class="item-name">{{ site.name_en }}</div>
                             <span class="heritage-badge" [class.badge-cultural]="site.category_short === 'C'"
@@ -159,34 +201,45 @@
         </div>
     </div>
 
-    <!-- Heritage Site Detail Modal -->
-    <div class="modal-overlay" *ngIf="selectedSite" (click)="closeSiteDetails()">
-        <div class="modal-content glass-panel fade-in" (click)="$event.stopPropagation()">
-            <button class="modal-close" (click)="closeSiteDetails()">×</button>
+    <!-- Mobile Bottom Sheet -->
+    <div class="mobile-bottom-sheet" *ngIf="selectedSite" [class.expanded]="bottomSheetExpanded"
+        (touchstart)="onSheetTouchStart($event)" (touchend)="onSheetTouchEnd($event)">
 
-            <div class="modal-header">
-                <span class="heritage-badge" [class.badge-cultural]="selectedSite.category_short === 'C'"
-                    [class.badge-natural]="selectedSite.category_short === 'N'"
-                    [class.badge-mixed]="selectedSite.category_short === 'C/N' || selectedSite.category_short === 'N/C'">
-                    {{ selectedSite.category_short === 'C' ? 'Cultural' : selectedSite.category_short === 'N' ?
-                    'Natural' : 'Mixed' }}
-                </span>
-                <h2 class="modal-title">{{ selectedSite.name_en }}</h2>
-            </div>
+        <!-- Drag handle — tap toggles, swipe controls state -->
+        <div class="sheet-handle-wrap">
+            <div class="sheet-handle"></div>
+        </div>
 
-            <div class="modal-body">
-                <div class="modal-description">
-                    <h3>Description</h3>
-                    <p>{{ selectedSite.short_description_en }}</p>
+        <div class="sheet-content" (scroll)="onSheetContentScroll($event)">
+            <div class="sheet-header">
+                <div class="sheet-title-row">
+                    <span class="heritage-badge" [class.badge-cultural]="selectedSite.category_short === 'C'"
+                        [class.badge-natural]="selectedSite.category_short === 'N'"
+                        [class.badge-mixed]="selectedSite.category_short === 'C/N' || selectedSite.category_short === 'N/C'">
+                        {{ selectedSite.category_short === 'C' ? 'Cultural' : selectedSite.category_short === 'N' ?
+                        'Natural' : 'Mixed' }}
+                    </span>
+                    <h2 class="sheet-name">{{ selectedSite.name_en }}</h2>
+                    <button class="detail-close-btn" (click)="closeSiteDetails(); $event.stopPropagation()"
+                        title="Close">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2.5" stroke-linecap="round">
+                            <line x1="18" y1="6" x2="6" y2="18" />
+                            <line x1="6" y1="6" x2="18" y2="18" />
+                        </svg>
+                    </button>
                 </div>
-
-                <div class="modal-actions" *ngIf="vm$ | async as vm">
-                    <button class="btn-visited" [class.visited]="isPOIVisited(selectedSite.id_no, vm.profile)"
-                        (click)="togglePOIVisited(selectedSite.id_no, vm.profile, vm.country?.id)">
-                        {{ isPOIVisited(selectedSite.id_no, vm.profile) ? 'Visited' : 'Mark Visited' }}
+            </div>
+            <div class="sheet-body">
+                <p class="detail-panel-desc">{{ selectedSite.short_description_en }}</p>
+                <div class="detail-panel-actions" *ngIf="vm$ | async as vm2">
+                    <button class="btn-visited" [class.visited]="isPOIVisited(selectedSite.id_no, vm2.profile)"
+                        (click)="togglePOIVisited(selectedSite.id_no, vm2.profile, vm2.country?.id)">
+                        {{ isPOIVisited(selectedSite.id_no, vm2.profile) ? 'Visited ✓' : 'Mark Visited' }}
                     </button>
                 </div>
             </div>
         </div>
     </div>
+
 </div>

--- a/src/app/components/country-detail/country-detail.component.ts
+++ b/src/app/components/country-detail/country-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, HostListener } from '@angular/core';
+import { Component, OnInit, HostListener, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TravelService } from '../../services/travel.service';
@@ -13,20 +13,27 @@ interface SubdivisionGroup {
 import { Observable, combineLatest, firstValueFrom } from 'rxjs';
 import { map, switchMap, startWith, take } from 'rxjs/operators';
 import { WorldMapComponent } from '../world-map/world-map.component';
+import { FormsModule } from '@angular/forms';
 import { Location } from '@angular/common';
 
 @Component({
     selector: 'app-country-detail',
     standalone: true,
-    imports: [CommonModule, WorldMapComponent],
+    imports: [CommonModule, WorldMapComponent, FormsModule],
     templateUrl: './country-detail.component.html',
     styleUrls: ['./country-detail.component.css']
 })
 export class CountryDetailComponent implements OnInit {
+    @ViewChild(WorldMapComponent) worldMap?: WorldMapComponent;
+
     activeTab: 'subdivisions' | 'heritage' = 'subdivisions';
     infoExpanded = false;
     selectedSite: any = null;
     statusMenuOpen = false;
+    hoveredSiteId: string | null = null;
+    hoveredSubdivisionCode: string | null = null;
+    /** Controls the mobile bottom-sheet expansion */
+    bottomSheetExpanded = false;
 
     vm$: Observable<{
         country: Country | null,
@@ -146,9 +153,19 @@ export class CountryDetailComponent implements OnInit {
         this.travel.setCountryStatus(countryId, status);
     }
 
-    @HostListener('document:click')
-    onDocumentClick() {
+    @HostListener('document:click', ['$event'])
+    onDocumentClick(event: MouseEvent) {
         this.statusMenuOpen = false;
+        // Close the site detail panel when clicking outside of it
+        if (this.selectedSite) {
+            const target = event.target as HTMLElement;
+            const inPanel = target.closest('.site-detail-panel');
+            const inCard = target.closest('.heritage-card');
+            const inMap = target.closest('.country-map-section'); // pin clicks open the panel, don't re-close
+            if (!inPanel && !inCard && !inMap) {
+                this.closeSiteDetails();
+            }
+        }
     }
 
     isSubdivisionVisited(subdivisionId: string, profile: UserProfile | null): boolean {
@@ -183,8 +200,11 @@ export class CountryDetailComponent implements OnInit {
 
     openSiteDetails(site: any) {
         this.selectedSite = site;
-        // Prevent body scroll when modal is open
-        document.body.style.overflow = 'hidden';
+        this.bottomSheetExpanded = false;
+        // Fly the map to the selected site
+        if (this.worldMap) {
+            this.worldMap.flyToSite(site.id_no);
+        }
     }
 
     openSiteFromPin(poiId: string, heritageSites: any[]) {
@@ -194,7 +214,46 @@ export class CountryDetailComponent implements OnInit {
 
     closeSiteDetails() {
         this.selectedSite = null;
-        document.body.style.overflow = 'auto';
+    }
+
+    setSiteHover(siteId: string | null) {
+        this.hoveredSiteId = siteId;
+    }
+
+    setSubdivisionHover(code: string | null) {
+        this.hoveredSubdivisionCode = code;
+    }
+
+    // ── Mobile bottom sheet touch gestures ──────────────────
+    private sheetTouchStartY = 0;
+    private sheetContentScrollTop = 0;
+
+    onSheetTouchStart(e: TouchEvent) {
+        this.sheetTouchStartY = e.touches[0].clientY;
+    }
+
+    onSheetTouchEnd(e: TouchEvent) {
+        const deltaY = e.changedTouches[0].clientY - this.sheetTouchStartY;
+        const threshold = 50;
+
+        if (deltaY < -threshold) {
+            // Swipe up — expand
+            this.bottomSheetExpanded = true;
+        } else if (deltaY > threshold) {
+            if (this.bottomSheetExpanded) {
+                // Swipe down while expanded — only collapse if content is at top
+                if (this.sheetContentScrollTop <= 0) {
+                    this.bottomSheetExpanded = false;
+                }
+            } else {
+                // Swipe down while peeking — dismiss
+                this.closeSiteDetails();
+            }
+        }
+    }
+
+    onSheetContentScroll(e: Event) {
+        this.sheetContentScrollTop = (e.target as HTMLElement).scrollTop;
     }
 
     private pluralizeDivisionType(type: string): string {

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, ViewChild, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { TravelService } from '../../services/travel.service';
@@ -17,6 +17,8 @@ import { WorldMapComponent } from '../world-map/world-map.component';
   styleUrls: ['./home.css']
 })
 export class HomeComponent implements OnInit {
+
+  @ViewChild(WorldMapComponent) worldMap?: WorldMapComponent;
 
   listMode: 'countries' | 'heritage' | 'planned' = 'countries';
 
@@ -99,30 +101,47 @@ export class HomeComponent implements OnInit {
   }
 
   highlightedCountry: Country | null = null;
+  hoveredSiteId: string | null = null;
+  selectedSite: any = null;
+  bottomSheetExpanded = false;
+
+  // ── Mobile bottom sheet touch gestures ──────────────────
+  private sheetTouchStartY = 0;
+  private sheetContentScrollTop = 0;
+
+  onSheetTouchStart(e: TouchEvent) {
+    this.sheetTouchStartY = e.touches[0].clientY;
+  }
+
+  onSheetTouchEnd(e: TouchEvent) {
+    const deltaY = e.changedTouches[0].clientY - this.sheetTouchStartY;
+    const threshold = 50;
+    if (deltaY < -threshold) {
+      this.bottomSheetExpanded = true;
+    } else if (deltaY > threshold) {
+      if (this.bottomSheetExpanded) {
+        if (this.sheetContentScrollTop <= 0) this.bottomSheetExpanded = false;
+      } else {
+        this.closeSiteDetails();
+      }
+    }
+  }
+
+  onSheetContentScroll(e: Event) {
+    this.sheetContentScrollTop = (e.target as HTMLElement).scrollTop;
+  }
 
   focusOnMap(country: Country) {
     this.highlightedCountry = country;
   }
 
-  focusHeritageSite(site: any) {
-    if (site?.latitude && site?.longitude) {
-      this.highlightedCountry = {
-        latitude: site.latitude,
-        longitude: site.longitude,
-        name: site.name_en
-      } as any;
-    }
-  }
-
-  selectedSite: any = null;
-
-  navigateToCountry(countryId: string) {
-    this.router.navigate(['/explore', countryId]);
-  }
-
   openSiteDetails(site: any) {
     this.selectedSite = site;
-    document.body.style.overflow = 'hidden';
+    this.bottomSheetExpanded = false;
+    // Fly map to the site
+    if (this.worldMap) {
+      this.worldMap.flyToSite(site.id_no);
+    }
   }
 
   openSiteFromPin(poiId: string, heritageSites: any[]) {
@@ -132,14 +151,32 @@ export class HomeComponent implements OnInit {
 
   closeSiteDetails() {
     this.selectedSite = null;
-    document.body.style.overflow = 'auto';
+    this.bottomSheetExpanded = false;
+  }
+
+  setSiteHover(siteId: string | null) {
+    this.hoveredSiteId = siteId;
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent) {
+    if (this.selectedSite) {
+      const target = event.target as HTMLElement;
+      const inPanel = target.closest('.home-site-panel');
+      const inRow = target.closest('.heritage-row');
+      const inMap = target.closest('.map-panel');
+      if (!inPanel && !inRow && !inMap) {
+        this.closeSiteDetails();
+      }
+    }
   }
 
   isPOIVisited(poiId: string, profile: UserProfile | null): boolean {
     return profile?.visitedPOIs?.includes(poiId) || false;
   }
 
-  async togglePOIVisited(poiId: string, profile: UserProfile | null) {
+  async togglePOIVisited(poiId: string, profile: UserProfile | null, event?: Event) {
+    if (event) event.stopPropagation();
     const user = await firstValueFrom(this.auth.user$.pipe(take(1)));
     if (!user) {
       this.auth.loginWithGoogle();
@@ -147,5 +184,9 @@ export class HomeComponent implements OnInit {
     }
     const visited = profile?.visitedPOIs?.includes(poiId) || false;
     this.travel.markPOIVisited(poiId, !visited);
+  }
+
+  navigateToCountry(countryId: string) {
+    this.router.navigate(['/explore', countryId]);
   }
 }

--- a/src/app/components/home/home.css
+++ b/src/app/components/home/home.css
@@ -2,10 +2,10 @@
 .home-container {
     max-width: 1600px;
     margin: 0 auto;
-    padding: 0.5rem 1.5rem 0.5rem;
+    padding: 0 1.5rem 0;
     display: flex;
     flex-direction: column;
-    height: calc(100vh - 80px);
+    height: calc(100vh - 160px);
     gap: 0.6rem;
     box-sizing: border-box;
 }
@@ -87,7 +87,6 @@
     grid-template-columns: 1fr 280px;
     gap: 1rem;
     flex: 1;
-    max-height: 72vh;
     min-height: 0;
 }
 

--- a/src/app/components/home/home.css
+++ b/src/app/components/home/home.css
@@ -349,7 +349,7 @@
 @media (max-width: 900px) {
     .home-container {
         height: auto;
-        padding: 0.75rem 1rem;
+        padding: 0 1rem 0.75rem 1rem;
     }
 
     .top-bar {
@@ -400,131 +400,234 @@
 }
 
 
-/* ── Modal ────────────────────────────────────────────────── */
-.modal-overlay {
+/* ── Heritage row selected state ────────────────────────── */
+.heritage-row-selected {
+    background: var(--glass-hover);
+}
+
+.heritage-row-selected .heritage-row-name {
+    color: var(--primary);
+}
+
+/* Bottom sheet — hidden on desktop */
+.home-bottom-sheet {
+    display: none;
+}
+
+/* ── Fixed side panel (mirrors country-detail panel) ──── */
+.home-site-panel {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.75);
-    backdrop-filter: blur(8px);
-    z-index: 1000;
+    top: 5.5rem;
+    right: 0;
+    width: 320px;
+    height: auto;
+    max-height: calc(100vh - 6.5rem);
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-card);
+    border-left: 1px solid var(--glass-border);
+    border-top: 1px solid var(--glass-border);
+    border-bottom: 1px solid var(--glass-border);
+    border-radius: 14px 0 0 14px;
+    box-shadow: -4px 4px 24px rgba(0, 0, 0, .25);
+    z-index: 200;
+    animation: panelSlideIn .2s ease;
+    overflow: hidden
+}
+
+@keyframes panelSlideIn {
+    from {
+        opacity: 0;
+        transform: translateX(16px)
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0)
+    }
+}
+
+.detail-panel-header {
+    padding: 1.25rem 1.25rem .75rem;
+    border-bottom: 1px solid var(--glass-border);
+    flex-shrink: 0
+}
+
+.detail-panel-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    margin-bottom: .6rem
+}
+
+.detail-close-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 1px solid var(--glass-border);
+    background: var(--bg-card);
+    color: var(--text-muted);
+    cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1rem;
+    flex-shrink: 0;
+    transition: background .15s ease, color .15s ease
 }
 
-.modal-content {
-    width: 100%;
-    max-width: 600px;
-    max-height: 90vh;
-    overflow-y: auto;
-    background: var(--bg-card);
-    border: 1px solid var(--glass-border);
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    padding: 0;
+.detail-close-btn:hover {
+    background: var(--glass-hover);
+    color: var(--text-main)
 }
 
-.modal-close {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    font-size: 2rem;
-    cursor: pointer;
-    line-height: 1;
-    z-index: 10;
-    transition: color 0.2s ease;
-}
-
-.modal-close:hover {
-    color: var(--text-main);
-}
-
-.modal-header {
-    padding: 2.5rem 2rem 1.5rem;
-    border-bottom: 1px solid var(--glass-border);
-}
-
-.modal-title {
-    font-size: 1.75rem;
-    margin-top: 0.75rem;
-}
-
-.modal-body {
-    padding: 2rem;
-}
-
-.modal-description h3 {
-    font-size: 1.1rem;
-    margin-bottom: 0.75rem;
-    color: var(--text-main);
-}
-
-.modal-description p {
-    color: var(--text-muted);
-    line-height: 1.7;
-    font-size: 0.95rem;
-}
-
-.modal-actions {
-    margin-top: 2.5rem;
-    display: flex;
-    gap: 1rem;
-    border-top: 1px solid var(--glass-border);
-    padding-top: 1.5rem;
-}
-
-/* Badge + button styles for modal */
-.heritage-badge {
-    padding: 0.2rem 0.6rem;
-    border-radius: 6px;
-    font-size: 0.7rem;
+.detail-panel-name {
+    font-size: 1.05rem;
     font-weight: 700;
-    white-space: nowrap;
+    color: var(--text-main);
+    margin: 0;
+    line-height: 1.35
 }
 
-.badge-cultural {
-    background: rgba(74, 144, 217, 0.15);
-    color: #4A90D9;
-    border: 1px solid rgba(74, 144, 217, 0.3);
+.detail-panel-body {
+    padding: 1rem 1.25rem;
+    flex: 1;
+    overflow-y: auto
 }
 
-.badge-natural {
-    background: rgba(39, 174, 96, 0.15);
-    color: #27AE60;
-    border: 1px solid rgba(39, 174, 96, 0.3);
+.detail-panel-desc {
+    font-size: .875rem;
+    color: var(--text-muted);
+    line-height: 1.65;
+    margin: 0 0 1.25rem
 }
 
-.badge-mixed {
-    background: rgba(230, 126, 34, 0.15);
-    color: #E67E22;
-    border: 1px solid rgba(230, 126, 34, 0.3);
+.detail-panel-actions {
+    display: flex;
+    gap: .75rem
 }
 
 .btn-visited {
-    padding: 0.55rem 1.1rem;
+    padding: .55rem 1.1rem;
     border-radius: 10px;
     border: 2px solid var(--glass-border);
     background: transparent;
     color: var(--text-main);
     cursor: pointer;
-    font-size: 0.9rem;
+    font-size: .9rem;
     font-weight: 600;
-    transition: all 0.3s ease;
-    white-space: nowrap;
+    transition: all .3s ease;
+    white-space: nowrap
 }
 
 .btn-visited.visited {
     background: var(--primary);
     border-color: var(--primary);
-    color: white;
+    color: white
+}
+
+.heritage-badge {
+    padding: .2rem .6rem;
+    border-radius: 6px;
+    font-size: .7rem;
+    font-weight: 700;
+    white-space: nowrap;
+    flex-shrink: 0
+}
+
+.badge-cultural {
+    background: rgba(74, 144, 217, .15);
+    color: #4A90D9;
+    border: 1px solid rgba(74, 144, 217, .3)
+}
+
+.badge-natural {
+    background: rgba(39, 174, 96, .15);
+    color: #27AE60;
+    border: 1px solid rgba(39, 174, 96, .3)
+}
+
+.badge-mixed {
+    background: rgba(230, 126, 34, .15);
+    color: #E67E22;
+    border: 1px solid rgba(230, 126, 34, .3)
+}
+
+@media(max-width:600px) {
+
+    /* Hide the desktop fixed panel */
+    .home-site-panel {
+        display: none
+    }
+
+    /* Show the bottom sheet */
+    .home-bottom-sheet {
+        display: flex;
+        flex-direction: column;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 500;
+        background: var(--bg-card);
+        border-top: 1px solid var(--glass-border);
+        border-radius: 18px 18px 0 0;
+        box-shadow: 0 -8px 32px rgba(0, 0, 0, .25);
+        max-height: 45vh;
+        transition: max-height .3s cubic-bezier(.4, 0, .2, 1);
+        touch-action: pan-y
+    }
+
+    .home-bottom-sheet.expanded {
+        max-height: 88vh
+    }
+
+    .home-bottom-sheet .sheet-handle-wrap {
+        padding: .75rem;
+        display: flex;
+        justify-content: center;
+        flex-shrink: 0;
+        touch-action: none;
+        user-select: none
+    }
+
+    .home-bottom-sheet .sheet-handle {
+        width: 44px;
+        height: 4px;
+        background: var(--glass-border);
+        border-radius: 2px
+    }
+
+    .home-bottom-sheet .sheet-content {
+        overflow-y: auto;
+        flex: 1;
+        overscroll-behavior: contain
+    }
+
+    .home-bottom-sheet .sheet-header {
+        padding: 0 1.25rem .9rem;
+        border-bottom: 1px solid var(--glass-border)
+    }
+
+    .home-bottom-sheet .sheet-title-row {
+        display: flex;
+        align-items: flex-start;
+        gap: .5rem
+    }
+
+    .home-bottom-sheet .sheet-name {
+        font-size: .95rem;
+        font-weight: 700;
+        color: var(--text-main);
+        margin: 0;
+        flex: 1;
+        min-width: 0;
+        line-height: 1.35
+    }
+
+    .home-bottom-sheet .sheet-body {
+        padding: 1rem 1.25rem
+    }
 }
 
 /* Animations */

--- a/src/app/components/home/home.html
+++ b/src/app/components/home/home.html
@@ -47,8 +47,8 @@
                 [visitedCountryNames]="listMode === 'planned' ? vm.plannedCountryNames : vm.visitedCountryNames"
                 [plannedCountryNames]="listMode === 'planned' ? vm.visitedCountryNames : vm.plannedCountryNames"
                 [focusedCountry]="highlightedCountry" [heritageSites]="vm.heritageSites"
-                [visitedPOIIds]="vm.visitedPOIIds" [showOnlyVisitedSites]="true" [height]="'600px'"
-                (poiToggled)="openSiteFromPin($event, vm.heritageSites)">
+                [visitedPOIIds]="vm.visitedPOIIds" [showOnlyVisitedSites]="true" [height]="'100%'"
+                [highlightedSiteId]="hoveredSiteId" (poiToggled)="openSiteFromPin($event, vm.heritageSites)">
             </app-world-map>
         </section>
 
@@ -112,11 +112,11 @@
                 <!-- Heritage Sites list -->
                 <ng-container *ngIf="listMode === 'heritage'">
                     <div class="heritage-row" *ngFor="let h of vm.visitedHeritageSites"
-                        (click)="focusHeritageSite(h.site)">
+                        [class.heritage-row-selected]="selectedSite?.id_no === h.site.id_no"
+                        (mouseenter)="setSiteHover(h.site.id_no)" (mouseleave)="setSiteHover(null)"
+                        (click)="openSiteDetails(h.site)">
                         <div class="heritage-row-info">
-                            <span class="heritage-row-name row-link"
-                                (click)="$event.stopPropagation(); openSiteDetails(h.site)" title="Open site details">{{
-                                h.site.name_en }}</span>
+                            <span class="heritage-row-name">{{ h.site.name_en }}</span>
                             <span class="heritage-row-sub"><span class="flag-emoji">{{ h.countryEmoji }}</span> {{
                                 h.countryName }}</span>
                         </div>
@@ -132,33 +132,75 @@
 
     </div>
 
-    <!-- Heritage Site Detail Modal -->
-    <div class="modal-overlay" *ngIf="selectedSite" (click)="closeSiteDetails()">
-        <div class="modal-content glass-panel fade-in" (click)="$event.stopPropagation()">
-            <button class="modal-close" (click)="closeSiteDetails()">×</button>
-
-            <div class="modal-header">
+    <!-- Fixed side panel for heritage site details (desktop) -->
+    <div class="home-site-panel" *ngIf="selectedSite">
+        <div class="detail-panel-header">
+            <div class="detail-panel-title-row">
                 <span class="heritage-badge" [class.badge-cultural]="selectedSite.category_short === 'C'"
                     [class.badge-natural]="selectedSite.category_short === 'N'"
                     [class.badge-mixed]="selectedSite.category_short === 'C/N' || selectedSite.category_short === 'N/C'">
                     {{ selectedSite.category_short === 'C' ? 'Cultural' : selectedSite.category_short === 'N' ?
                     'Natural' : 'Mixed' }}
                 </span>
-                <h2 class="modal-title">{{ selectedSite.name_en }}</h2>
+                <button class="detail-close-btn" (click)="closeSiteDetails()" title="Close">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+                        stroke-linecap="round">
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                </button>
             </div>
+            <h2 class="detail-panel-name">{{ selectedSite.name_en }}</h2>
+        </div>
+        <div class="detail-panel-body" *ngIf="vm$ | async as vm2">
+            <p class="detail-panel-desc">{{ selectedSite.short_description_en }}</p>
+            <div class="detail-panel-actions">
+                <button class="btn-visited" [class.visited]="isPOIVisited(selectedSite.id_no, vm2.profile)"
+                    (click)="togglePOIVisited(selectedSite.id_no, vm2.profile, $event)">
+                    {{ isPOIVisited(selectedSite.id_no, vm2.profile) ? 'Visited ✓' : 'Mark Visited' }}
+                </button>
+            </div>
+        </div>
+    </div>
 
-            <div class="modal-body">
-                <div class="modal-description">
-                    <h3>Description</h3>
-                    <p>{{ selectedSite.short_description_en }}</p>
+    <!-- Mobile bottom sheet (shown ≤600px, hidden on desktop) -->
+    <div class="home-bottom-sheet" *ngIf="selectedSite" [class.expanded]="bottomSheetExpanded"
+        (touchstart)="onSheetTouchStart($event)" (touchend)="onSheetTouchEnd($event)">
+
+        <div class="sheet-handle-wrap">
+            <div class="sheet-handle"></div>
+        </div>
+
+        <div class="sheet-content" (scroll)="onSheetContentScroll($event)">
+            <div class="sheet-header">
+                <div class="sheet-title-row">
+                    <span class="heritage-badge" [class.badge-cultural]="selectedSite.category_short === 'C'"
+                        [class.badge-natural]="selectedSite.category_short === 'N'"
+                        [class.badge-mixed]="selectedSite.category_short === 'C/N' || selectedSite.category_short === 'N/C'">
+                        {{ selectedSite.category_short === 'C' ? 'Cultural' : selectedSite.category_short === 'N' ?
+                        'Natural' : 'Mixed' }}
+                    </span>
+                    <h2 class="sheet-name">{{ selectedSite.name_en }}</h2>
+                    <button class="detail-close-btn" (click)="closeSiteDetails(); $event.stopPropagation()"
+                        title="Close">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2.5" stroke-linecap="round">
+                            <line x1="18" y1="6" x2="6" y2="18" />
+                            <line x1="6" y1="6" x2="18" y2="18" />
+                        </svg>
+                    </button>
                 </div>
-
-                <div class="modal-actions">
-                    <button class="btn-visited visited" (click)="togglePOIVisited(selectedSite.id_no, vm.profile)">
-                        Visited
+            </div>
+            <div class="sheet-body" *ngIf="vm$ | async as vm2">
+                <p class="detail-panel-desc">{{ selectedSite.short_description_en }}</p>
+                <div class="detail-panel-actions">
+                    <button class="btn-visited" [class.visited]="isPOIVisited(selectedSite.id_no, vm2.profile)"
+                        (click)="togglePOIVisited(selectedSite.id_no, vm2.profile, $event)">
+                        {{ isPOIVisited(selectedSite.id_no, vm2.profile) ? 'Visited ✓' : 'Mark Visited' }}
                     </button>
                 </div>
             </div>
         </div>
     </div>
+
 </div>

--- a/src/app/components/navbar/navbar.scss
+++ b/src/app/components/navbar/navbar.scss
@@ -4,7 +4,6 @@
     position: sticky;
     top: 1rem;
     z-index: 1000;
-    background: var(--bg-card);
 }
 
 .nav-content {

--- a/src/app/components/world-map/world-map.component.ts
+++ b/src/app/components/world-map/world-map.component.ts
@@ -23,6 +23,8 @@ export class WorldMapComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
     @Input() showOnlyVisitedSites: boolean = false;
     @Input() countryId: string = '';
     @Input() visitedSubdivisionCodes: string[] = [];
+    @Input() highlightedSiteId: string | null = null;
+    @Input() highlightedSubdivisionCode: string | null = null;
 
     @Output() poiToggled = new EventEmitter<string>();
 
@@ -80,6 +82,14 @@ export class WorldMapComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
         if ((changes['visitedPOIIds'] || changes['heritageSites']) &&
             !(changes['visitedPOIIds']?.firstChange && changes['heritageSites']?.firstChange)) {
             this.updateHeritageLayers();
+        }
+
+        if (changes['highlightedSiteId'] && !changes['highlightedSiteId'].firstChange) {
+            this.updateSiteHighlight();
+        }
+
+        if (changes['highlightedSubdivisionCode'] && !changes['highlightedSubdivisionCode'].firstChange) {
+            this.updateSubdivisionHighlight();
         }
     }
 
@@ -247,6 +257,93 @@ export class WorldMapComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
         } else if (this.heritageSites.length > 0) {
             this.addHeritageLayers(geojson);
         }
+    }
+
+    /**
+     * Fly the map to a specific heritage site by its id_no
+     */
+    flyToSite(siteIdNo: string) {
+        if (!this.map) return;
+        const site = this.heritageSites.find(s => s.id_no === siteIdNo);
+        if (site && site.longitude && site.latitude) {
+            this.map.flyTo({
+                center: [site.longitude, site.latitude],
+                zoom: 8,
+                essential: true
+            });
+        }
+    }
+
+    /**
+     * Highlight (or un-highlight) a heritage site pin
+     */
+    private updateSiteHighlight() {
+        if (!this.map || !this.mapReady) return;
+
+        const highlightLayerId = 'heritage-sites-highlight';
+        if (this.map.getLayer(highlightLayerId)) {
+            this.map.removeLayer(highlightLayerId);
+        }
+        if (this.map.getSource('heritage-highlight')) {
+            this.map.removeSource('heritage-highlight');
+        }
+
+        if (!this.highlightedSiteId) return;
+
+        const site = this.heritageSites.find(s => s.id_no === this.highlightedSiteId);
+        if (!site || !site.longitude || !site.latitude) return;
+
+        const geojson: GeoJSON.FeatureCollection = {
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [site.longitude, site.latitude] },
+                properties: {}
+            }]
+        };
+
+        this.map.addSource('heritage-highlight', { type: 'geojson', data: geojson });
+        this.map.addLayer({
+            id: highlightLayerId,
+            type: 'circle',
+            source: 'heritage-highlight',
+            paint: {
+                'circle-radius': 14,
+                'circle-color': '#ffffff',
+                'circle-opacity': 0.25,
+                'circle-stroke-color': '#ffffff',
+                'circle-stroke-width': 2.5
+            }
+        });
+    }
+
+    /**
+     * Highlight (or un-highlight) a subdivision polygon
+     */
+    private updateSubdivisionHighlight() {
+        if (!this.map || !this.mapReady || !this.countryId) return;
+
+        const highlightLayerId = `${this.countryId.toLowerCase()}-regions-highlight`;
+        if (this.map.getLayer(highlightLayerId)) {
+            this.map.removeLayer(highlightLayerId);
+        }
+
+        if (!this.highlightedSubdivisionCode) return;
+
+        const sourceId = `${this.countryId.toLowerCase()}-regions`;
+        if (!this.map.getSource(sourceId)) return;
+
+        this.map.addLayer({
+            id: highlightLayerId,
+            type: 'line',
+            source: sourceId,
+            filter: ['==', ['get', 'code'], this.highlightedSubdivisionCode],
+            paint: {
+                'line-color': '#ffffff',
+                'line-width': 2.5,
+                'line-opacity': 0.9
+            }
+        });
     }
 
     private lastIsDark: boolean | null = null;
@@ -441,20 +538,26 @@ export class WorldMapComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
             'countries-focused-fill',
             'countries-borders',
             'heritage-sites-visited',
-            'heritage-sites-unvisited'
+            'heritage-sites-unvisited',
+            'heritage-sites-highlight'
         ];
 
         // Add dynamic region layers to removal list
         if (this.countryId) {
             const sourceId = `${this.countryId.toLowerCase()}-regions`;
-            layersToRemove.push(`${sourceId}-borders`, `${sourceId}-fill`, `${sourceId}-visited-fill`);
+            layersToRemove.push(
+                `${sourceId}-borders`,
+                `${sourceId}-fill`,
+                `${sourceId}-visited-fill`,
+                `${sourceId}-highlight`
+            );
         }
 
         layersToRemove.forEach(layer => {
             if (this.map.getLayer(layer)) this.map.removeLayer(layer);
         });
 
-        const sourcesToRemove = ['world-countries', 'heritage-sites'];
+        const sourcesToRemove = ['world-countries', 'heritage-sites', 'heritage-highlight'];
         if (this.countryId) {
             sourcesToRemove.push(`${this.countryId.toLowerCase()}-regions`);
         }

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,7 +47,7 @@ html.light {
 
 body {
   background-color: var(--bg-dark);
-  min-height: 100vh;
+  min-height: 100%;
   color: var(--text-main);
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   line-height: 1.6;
@@ -182,14 +182,6 @@ h4,
 [data-theme="Neon"] {
   --neon-glow: var(--primary);
   --neon-glow-rgb: var(--primary-rgb);
-}
-
-/* Navbar & dropdown: translucent glass instead of solid bg-card */
-[data-theme="Neon"] .navbar {
-  background: rgba(10, 10, 10, 0.85) !important;
-  backdrop-filter: blur(20px) !important;
-  -webkit-backdrop-filter: blur(20px) !important;
-  border: 1px solid rgba(var(--neon-glow-rgb), 0.15) !important;
 }
 
 [data-theme="Neon"] .dropdown-menu {


### PR DESCRIPTION
Fixed #2 

Removed the modal that would show heritage sites, replaced the functionality with a details popup on the side for desktop and a bottom details popup for mobile.

Clicking heritage sites on from the list or the map on dashboard or country view pans and zooms the map to the point and opens the details popup.